### PR TITLE
Optionally reduce obesity while converting snapshots. #24

### DIFF
--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -37,3 +37,8 @@ This should launch an interactive dashboard. Or you can run the simulation in
 ```shell
 poetry run python headless.py -p config/WestYorkshireSmall.yml
 ```
+
+### Extra options
+
+You can transform individuals to a lower level of obesity by running
+`convert_snapshot.py` with the `--reduce_obesity` flag.


### PR DESCRIPTION
You can now specify `--reduce_obesity` while converting snapshots. The logic mimics https://github.com/Urban-Analytics/RAMP-UA/blob/c5ecee2ab8eebd2b9cffc41956c7c83195b709d1/coding/model/opencl/ramp/snapshot.py#L172. **Note** that the docstring in that reference code disagrees with the implementation. We're **not** transforming `overweight`.

If there's any ambiguity about the transformation being done, we can write the simple unit test and show the mapping exactly.